### PR TITLE
Remove stashing from `pre-commit`

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -4,17 +4,11 @@
 
 echo '[git hook] executing gradle spotlessCheck before commit'
 
-# stash any unstaged changes
-git stash -q --keep-index
-
 # run the spotlessCheck with the gradle wrapper
 ./gradlew spotlessCheck --daemon
 
 # store the last exit code in a variable
 RESULT=$?
-
-# unstash the unstashed changes
-git stash pop -q
 
 # return the './gradlew spotlessCheck' exit code
 exit $RESULT


### PR DESCRIPTION
For some reason the unstaged-changes stashing started (or it always did) breaking stuff, we can look at it after the season. Currently I just deleted it, anyway it's not that important to not Spotless unstaged changes.